### PR TITLE
Fix multiple preprocessing of content

### DIFF
--- a/views/index.pug
+++ b/views/index.pug
@@ -222,9 +222,14 @@ script(type="text/javascript").
     function preProcessContent() {
       // Get original content
       const contentDiv = document.getElementById('ir-content');
-      
+
       if (!useMixedLanguageProcessing) {
         // Don't modify content if not using mixed language processing
+        return;
+      }
+
+      // Avoid processing the same content multiple times
+      if (contentDiv.dataset.processed === 'true') {
         return;
       }
       
@@ -284,7 +289,8 @@ script(type="text/javascript").
           item.classList.add('chinese-section');
         }
       });
-      
+
+      contentDiv.dataset.processed = 'true';
       console.log("Content pre-processed for mixed language handling");
     }
 


### PR DESCRIPTION
## Summary
- avoid running the language separation preprocessing multiple times

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_684dd63255388333889cb75ca5f956c7